### PR TITLE
Fix ISO loading and update style

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,11 +37,11 @@ function openIsoDB(){
   return isoDBPromise;
 }
 
-async function saveIso(buf){
+async function saveIso(file){
   const db = await openIsoDB();
   return new Promise((res,rej)=>{
     const tx = db.transaction('isos','readwrite');
-    tx.objectStore('isos').put(buf,'uploaded');
+    tx.objectStore('isos').put(file,'uploaded');
     tx.oncomplete=()=>res();
     tx.onerror=e=>rej(e.target.error);
   });
@@ -98,18 +98,18 @@ isoUpload.addEventListener('change', async () => {
   if(!isoUpload.files[0]) return;
   startBtn.disabled = true;
   logMsg('Saving ISO...');
-  const buf = await isoUpload.files[0].arrayBuffer();
-  await saveIso(buf);
+  await saveIso(isoUpload.files[0]);
   logMsg('ISO saved');
   startBtn.disabled = false;
 });
 
 startBtn.onclick=async()=>{
-  let isoBuffer = await loadIso();
-  if(!isoBuffer){
+  let isoBlob = await loadIso();
+  if(!isoBlob){
     alert('Upload an ISO or IMG and wait for it to be saved');
     return;
   }
+  let isoBuffer = await isoBlob.arrayBuffer();
   Module = { preRun: [], arguments: [] };
   Module.print = logMsg;
   Module.printErr = logMsg;

--- a/style.css
+++ b/style.css
@@ -3,6 +3,9 @@ body {
   background-color: #f5f5f5;
   padding: 20px;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 h1 {
@@ -18,6 +21,8 @@ h1 {
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
+  width: 100%;
+  max-width: 800px;
 }
 
 button {
@@ -38,6 +43,7 @@ input {
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 4px;
+  margin-top: 10px;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- store uploaded ISO as a Blob instead of loading the whole ArrayBuffer
- update `start` logic to read the Blob on demand
- center the layout and add width limits for controls

## Testing
- `npm install`
- `nohup npx http-server -p 8080 -a 127.0.0.1 > /tmp/http.log 2>&1 &`
- `curl -I http://127.0.0.1:8080/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68595d6bf5cc833086b542c63096f5f1